### PR TITLE
Refine OCR quickstart script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,5 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+input_pdfs/
+results/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
-# mistral-quickstart
+# Mistral Document AI Quickstart
+
+This repository contains a small helper script to process PDF files using the
+[Mistral Document AI](https://docs.mistral.ai/capabilities/OCR/document_ai_overview/)
+OCR API. The script uploads each PDF to Mistral and stores the OCR output as
+Markdown, JSON and any extracted images.
+
+## Requirements
+
+- Python 3.8+
+ - The `mistralai` package (see `requirements.txt`)
+- A Mistral API key available in the environment as `MISTRAL_API_KEY`
+
+Install the dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Place the PDF documents you want to analyse inside the `input_pdfs/` directory
+(or specify another one via the command line). The script writes the output
+into the `results/` directory. For each input PDF a subdirectory is created
+containing `result.md`, `result.json` and an `images/` folder with any
+extracted figures.
+
+```bash
+export MISTRAL_API_KEY=your-token-here
+python ocr_quickstart.py input_pdfs results
+```
+
+Each processed PDF will generate a folder under `results/` mirroring the file
+name. Inside you will find the extracted text in `result.md`, the full response
+as `result.json` and an `images/` subfolder with the image files referenced from
+the Markdown.

--- a/ocr_quickstart.py
+++ b/ocr_quickstart.py
@@ -6,6 +6,8 @@ import base64
 from pathlib import Path
 from typing import Dict, Any
 
+from dotenv import load_dotenv
+
 from mistralai import Mistral
 
 
@@ -59,6 +61,7 @@ def save_result(result: Dict[str, Any], output_dir: Path) -> None:
 
 
 def main(input_dir: Path, output_dir: Path, api_key: str) -> None:
+    input_dir.mkdir(parents=True, exist_ok=True)
     output_dir.mkdir(parents=True, exist_ok=True)
     client = Mistral(api_key=api_key)
 
@@ -86,6 +89,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
+    load_dotenv()
     api_key = os.getenv("MISTRAL_API_KEY")
     if not api_key:
         raise SystemExit("MISTRAL_API_KEY environment variable not set")

--- a/ocr_quickstart.py
+++ b/ocr_quickstart.py
@@ -1,0 +1,93 @@
+"""Process PDFs with Mistral Document AI OCR and save markdown results."""
+
+import os
+import json
+import base64
+from pathlib import Path
+from typing import Dict, Any
+
+from mistralai import Mistral
+
+
+def ocr_pdf(client: Mistral, pdf_path: Path) -> Dict[str, Any]:
+    """Upload a PDF and perform OCR using the Mistral client."""
+    upload = client.files.upload(
+        file={"file_name": pdf_path.name, "content": pdf_path.open("rb")},
+        purpose="ocr",
+    )
+    signed_url = client.files.retrieve(file_id=upload.id)
+    response = client.ocr.process(
+        model="mistral-ocr-latest",
+        document={"type": "document_url", "document_url": signed_url.url},
+        include_image_base64=True,
+    )
+    # The response is an object, convert to dict if possible
+    if hasattr(response, "dict"):
+        return response.dict()
+    if hasattr(response, "model_dump"):
+        return response.model_dump()
+    return response
+
+
+def save_result(result: Dict[str, Any], output_dir: Path) -> None:
+    """Save OCR result as markdown, JSON and extracted images."""
+    text = result.get("text", "")
+    images = result.get("images", [])
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    md_path = output_dir / "result.md"
+    json_path = output_dir / "result.json"
+    images_dir = output_dir / "images"
+    images_dir.mkdir(exist_ok=True)
+
+    with md_path.open("w", encoding="utf-8") as md_file:
+        md_file.write(text)
+
+    with json_path.open("w", encoding="utf-8") as jf:
+        json.dump(result, jf, ensure_ascii=False, indent=2)
+
+    for img in images:
+        filename = img.get("filename", "image.png")
+        data = img.get("data", "")
+        img_path = images_dir / filename
+        if data:
+            with img_path.open("wb") as f:
+                f.write(base64.b64decode(data))
+        with md_path.open("a", encoding="utf-8") as md_file:
+            rel_path = img_path.relative_to(md_path.parent)
+            md_file.write(f"\n\n![{filename}]({rel_path})\n")
+
+
+def main(input_dir: Path, output_dir: Path, api_key: str) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    client = Mistral(api_key=api_key)
+
+    for pdf_file in input_dir.glob("*.pdf"):
+        print(f"Processing {pdf_file.name}...")
+        result = ocr_pdf(client, pdf_file)
+        save_result(result, output_dir / pdf_file.stem)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Process PDFs with Mistral OCR")
+    parser.add_argument(
+        "input_dir",
+        type=Path,
+        default=Path("input_pdfs"),
+        help="Directory containing PDF files",
+    )
+    parser.add_argument(
+        "output_dir",
+        type=Path,
+        default=Path("results"),
+        help="Directory to store results",
+    )
+    args = parser.parse_args()
+
+    api_key = os.getenv("MISTRAL_API_KEY")
+    if not api_key:
+        raise SystemExit("MISTRAL_API_KEY environment variable not set")
+
+    main(args.input_dir, args.output_dir, api_key)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+mistralai


### PR DESCRIPTION
## Summary
- revise script to use the `mistralai` client
- organize output by creating a folder per input PDF with markdown, JSON and extracted images
- document the new behaviour and dependency on `mistralai`

## Testing
- `python -m py_compile ocr_quickstart.py`
